### PR TITLE
Remove apiGroupVersion for aws managed control plane

### DIFF
--- a/pkg/cmds/config/capa.go
+++ b/pkg/cmds/config/capa.go
@@ -48,8 +48,7 @@ func NewCmdCAPA() *cobra.Command {
 			var out bytes.Buffer
 			var foundCP bool
 			err = parser.ProcessResources(in, func(ri parser.ResourceInfo) error {
-				if ri.Object.GetAPIVersion() == "controlplane.cluster.x-k8s.io/v1beta1" &&
-					ri.Object.GetKind() == "AWSManagedControlPlane" {
+				if ri.Object.GetKind() == "AWSManagedControlPlane" {
 					foundCP = true
 
 					netcfg := map[string]any{


### PR DESCRIPTION
For latest capa controller they used version v1beta2, where previous version was v1beta1 